### PR TITLE
[Low Priority] Fix for issue #2 – iOS 5.x SampleProject crash

### DIFF
--- a/MSCachedAsyncViewDrawing-SampleProject/MSCommonTVC.m
+++ b/MSCachedAsyncViewDrawing-SampleProject/MSCommonTVC.m
@@ -37,8 +37,6 @@
 {
     [super viewDidLoad];
 
-    [self.tableView registerClass:self.cellClass forCellReuseIdentifier:[self cellID]];
-
     self.tableView.backgroundColor = kBackgroundColor;
     self.tableView.rowHeight = kRowHeight;
 }
@@ -53,6 +51,11 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell<MSCustomDrawnViewCell> *cell = [tableView dequeueReusableCellWithIdentifier:[self cellID]];
+    if (cell == nil)
+    {
+        cell = [[self.cellClass alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:[self cellID]];
+    }
+
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
 
     cell.circleColors = [self circleColorsForIndexPath:indexPath];


### PR DESCRIPTION
This removes an iOS 6.0-only API for table view cell creation[1] and replaces it with the pre-6.0 dequeueing-and-checking-for-nil cell creation strategy. Since the sample project's deployment target is 5.0 and `MSCachedAsyncViewDrawing` supports iOS 5.0+, removing this crash makes the sample project experience a little smoother.

[1]: `-[UITableView registerClass:forCellReuseIdentifier:]`

An alternative approach would be to support both the iOS 6 cell-setup process and a fallback to the old strategy (see the diff below), but I'd say this adds too much noise for a sample project.

``` diff
diff --git a/MSCachedAsyncViewDrawing-SampleProject/MSCommonTVC.m b/MSCachedAsyncViewDrawing-SampleProject/MSCommonTVC.m
index 2fdf6a7..1f21052 100644
--- a/MSCachedAsyncViewDrawing-SampleProject/MSCommonTVC.m
+++ b/MSCachedAsyncViewDrawing-SampleProject/MSCommonTVC.m
@@ -37,7 +37,9 @@
 {
     [super viewDidLoad];

+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
     [self.tableView registerClass:self.cellClass forCellReuseIdentifier:[self cellID]];
+#endif

     self.tableView.backgroundColor = kBackgroundColor;
     self.tableView.rowHeight = kRowHeight;
@@ -53,6 +55,11 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell<MSCustomDrawnViewCell> *cell = [tableView dequeueReusableCellWithIdentifier:[self cellID]];
+    if (cell == nil)
+    {
+        cell = [[self.cellClass alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:[self cellID]];
+    }
+
     cell.selectionStyle = UITableViewCellSelectionStyleNone;

     cell.circleColors = [self circleColorsForIndexPath:indexPath];
```
